### PR TITLE
Move to alpine linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM ubuntu:14.04.1
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-    socat
+FROM alpine:3.1
+RUN apk add --update socat && \
+    rm -rf /var/cache/apk/*
 COPY ./run.sh /
 RUN chmod +x /run.sh
-ENTRYPOINT ["/run.sh"]
+CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.1
-RUN apk add --update socat && \
+RUN apk add --update socat bash && \
     rm -rf /var/cache/apk/*
 COPY ./run.sh /
 RUN chmod +x /run.sh


### PR DESCRIPTION
This image is a ~7MB vs the 180+MB for the ubuntu equivalent. This should speed up our tests.
